### PR TITLE
Ansible config: Always ask the vault pass

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,3 +8,4 @@ inventory = ./inventory/hosts
 
 # Read tmp files to enable become_user
 allow_world_readable_tmpfiles = true
+ask_vault_pass = true


### PR DESCRIPTION
We need to encrypt the secrets of the development environment and we always need to put in the command to execute the playbooks the arg `--ask-vault-pass`. This setting in the local Ansible config file avoids repeating the argument.