### PR TITLE
Change the entrypoint to run the Celery tasks

### DIFF
--- a/roles/systemd_service/templates/opencell-celery.service.j2
+++ b/roles/systemd_service/templates/opencell-celery.service.j2
@@ -2,7 +2,7 @@
 Description=Tryton-OpenCell Celery server
 
 [Service]
-ExecStart={{ virtualenv_path }}/bin/celery worker --workdir={{ eticom_path }}/trytond -A trytond.modules.opencell_somconnexio.tasks.tasks --loglevel=info --time-limit=7400
+ExecStart={{ virtualenv_path }}/bin/celery worker --workdir={{ eticom_path }}/trytond -A trytond.modules.opencell_somconnexio.opencell_somconnexio.tryton_tasks.tasks --loglevel=info --time-limit=7400
 EnvironmentFile=/etc/default/trytond
 
 User={{ tryton_user }}


### PR DESCRIPTION
After the last structure refactor, the entrypoint path of the Celery
OpenCell process was broken.

Refactor PR:
https://gitlab.com/coopdevs/opencell_somconnexio_tryton/merge_requests/24

After run this changes, be sure you have the next MR merged and deployed:
https://gitlab.com/coopdevs/opencell_somconnexio_tryton/merge_requests/32