### PR TITLE
Add script to restart all the Tryton services

### DIFF
--- a/roles/systemd_service/files/restart_all.sh
+++ b/roles/systemd_service/files/restart_all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+sudo systemctl restart trytond@eticom1
+sudo systemctl restart trytond@eticom2
+sudo systemctl restart trytond@eticom3
+sudo systemctl restart trytond@eticom4
+
+sudo systemctl restart trytond-cron
+sudo systemctl restart eticom-celery
+sudo systemctl restart opencell-celery

--- a/roles/systemd_service/tasks/main.yml
+++ b/roles/systemd_service/tasks/main.yml
@@ -91,3 +91,14 @@
     src: sudoers.j2
     dest: "/etc/sudoers.d/90-tryton-admins"
     mode: 0440
+
+- name: Create script to restart all Tryton
+  become: yes
+  become_user: "{{ tryton_user }}"
+  copy:
+    src: restart_all.sh
+    dest: "/home/{{ tryton_user }}/restart_all"
+    owner: "{{ tryton_user }}"
+    group: "{{ tryton_user }}"
+    mode: 0740
+

--- a/roles/systemd_service/tasks/main.yml
+++ b/roles/systemd_service/tasks/main.yml
@@ -94,11 +94,9 @@
 
 - name: Create script to restart all Tryton
   become: yes
-  become_user: "{{ tryton_user }}"
   copy:
     src: restart_all.sh
-    dest: "/home/{{ tryton_user }}/restart_all"
+    dest: "/usr/local/bin/tryton_restart_all"
     owner: "{{ tryton_user }}"
     group: "{{ tryton_user }}"
     mode: 0740
-


### PR DESCRIPTION
Add script to restart all the Tryton processes (runed with systemd) with only one command.

Now we need to execute:
```
$ sudo systemctl restart trytond@eticom1
$ sudo systemctl restart trytond@eticom2
$ sudo systemctl restart trytond@eticom3
$ sudo systemctl restart trytond@eticom4

$ sudo systemctl restart trytond-cron
$ sudo systemctl restart eticom-celery
$ sudo systemctl restart opencell-celery
```

With this change we can execute:
```
$ tryton_restart_all
```

And the result is the same.