### PR TITLE
Allow restart postgres with the Tyrton users

### DIFF
--- a/roles/systemd_service/templates/sudoers.j2
+++ b/roles/systemd_service/templates/sudoers.j2
@@ -52,3 +52,6 @@
 %{{ tryton_group }} ALL=(ALL) NOPASSWD: /bin/systemctl stop trytond-uwsgi
 %{{ tryton_group }} ALL=(ALL) NOPASSWD: /bin/systemctl restart trytond-uwsgi
 %{{ tryton_group }} ALL=(ALL) NOPASSWD: /bin/systemctl reload trytond-uwsgi
+# PostgreSQL
+%{{ tryton_group }} ALL=(ALL) NOPASSWD: /bin/systemctl restart postgresql
+%{{ tryton_group }} ALL=(ALL) NOPASSWD: /bin/systemctl reload postgresql


### PR DESCRIPTION
We need restart PostgreSQL frequently.

We need to run this restart with the `administrator` user or any user added to the `tryton` group.