### PR TITLE
Feature/script use prod db staging

### DIFF
--- a/roles/needed_data/tasks/main.yml
+++ b/roles/needed_data/tasks/main.yml
@@ -35,6 +35,15 @@
     owner: "{{ tryton_user }}"
     group: "{{ tryton_user }}"
 
+- name: Create script to prepare Production dump
+  become: yes
+  template:
+    src: prepare-prod-db.j2
+    dest: "/home/{{ tryton_user }}/prepare-prod-db"
+    mode: 0740
+    owner: "{{ tryton_user }}"
+    group: "{{ tryton_user }}"
+
 - name: Remove NGINX default server
   become: yes
   file:

--- a/roles/needed_data/templates/prepare-prod-db.j2
+++ b/roles/needed_data/templates/prepare-prod-db.j2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+(cd {{ tryton_path }}/modules/aeat_sii && hg up 293)
+(cd {{ tryton_path }}/modules/account_jasper_reports/ && hg up 315)
+(cd {{ tryton_path }}/modules/account_invoice_jreport/ && hg up 112)
+(cd {{ tryton_path }}/modules/jasper_reports_options/ && hg up 56)
+source /home/{{ tryton_user }}/update $1 jasper_reports_options
+source /home/{{ tryton_user }}/update $1 opencell_somconnexio
+source /home/{{ tryton_user }}/update $1 contract_changes_wizards_somconnexio
+source /home/{{ tryton_user }}/update $1 basetis
+source /home/{{ tryton_user }}/update $1 eticom


### PR DESCRIPTION
* Add script to use a prod db in dev/staging environment

This script implement the one step of the Prepare env of QA with Tryton
Production dump page. The Update modules and fix needed versions steps
to avoid errors with Mergurial.

https://gitlab.com/coopdevs/opencell_somconnexio_tryton/wikis/Prepare-env-of-QA-with-Tryton-Production-dump#update-modules-and-fix-needed-versions

* Use become and owner/group to create scripts

Use become in any task of needed_data and use the fields owner and group
to fix the permissions to execute and edit the script.

