### PR TITLE
Use different uwsgi config by environment.

### DIFF
--- a/inventory/host_vars/stagingtryton.coopdevs.org/config.yml
+++ b/inventory/host_vars/stagingtryton.coopdevs.org/config.yml
@@ -26,7 +26,7 @@ tryton_user_keys:
     state: present
 
 trytond_db_uri: 'postgresql://{{ db_user }}:{{ db_user_password }}@localhost:{{ db_port }}/{{ db_name }}'
-uwsgi_config: 'server-eticom-dev.ini'
+uwsgi_config: 'server-eticom-staging.ini'
 nginx_config: 'uwsgi-dev.nginx'
 
 # Integrations

--- a/roles/needed_data/templates/up-web.j2
+++ b/roles/needed_data/templates/up-web.j2
@@ -2,4 +2,4 @@
 
 set -a
 source {{ tryton_defaults }}
-{{ venv_path }}/bin/uwsgi --ini {{ galatea_path}}/server-eticom-dev.ini --honour-stdin
+{{ venv_path }}/bin/uwsgi --ini {{ galatea_path}}/{{ uwsgi_config }} --honour-stdin


### PR DESCRIPTION
We have problems with the listen config option of UWSGI
https://uwsgi-docs-additions.readthedocs.io/en/latest/Options.html#listen

In production we can define the maximum as 500 but in development and in
staging we need limit the maximum to 100 (the default value).