### PR TITLE
Upgrade packages to be in sync with the server

### DIFF
--- a/roles/system_packages/tasks/main.yml
+++ b/roles/system_packages/tasks/main.yml
@@ -8,19 +8,19 @@
       'quilt=0.63-8',
       'libxml2=2.9.4+dfsg1-2.2+deb9u2',
       'libxml2-dev=2.9.4+dfsg1-2.2+deb9u2',
-      'libxslt1-dev=1.1.29-2.1',
+      'libxslt1-dev=1.1.29-2.1+deb9u1',
       'build-essential=12.3',
       'enchant=1.6.0-11+b1',
       'libffi-dev=3.2.1-6',
-      'libssl-dev=1.1.0k-1~deb9u1',
-      'libldap2-dev=2.4.44+dfsg-5+deb9u2',
+      'libssl-dev=1.1.0l-1~deb9u1',
+      'libldap2-dev=2.4.44+dfsg-5+deb9u3',
       'libsasl2-dev=2.1.27~101-g0780600+dfsg-3',
       'unoconv=0.7-1.1',
       'libdwarf-dev=20161124-1+deb9u1',
       'libelf-dev=0.168-1',
       'libunwind-dev=1.1-4.1',
       'libunwind-dev=1.1-4.1',
-      'nginx=1.10.3-1+deb9u2',
+      'nginx=1.10.3-1+deb9u3',
       'openjdk-8-jre'
       ]
     state: present


### PR DESCRIPTION
The autoupgrade upgraded these 4 packages and now provisioning fails as
the versions don't match.