### PR TITLE
Grant SELECT on otrs_contract view

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -21,7 +21,7 @@
             role_attr_flags: CREATEDB
           - name: '{{ otrs_db_user }}'
             password: '{{ otrs_db_password }}'
-            priv: party_otrs_view:SELECT
+            priv: party_otrs_view:SELECT/otrs_contract:SELECT
             db: '{{ db_name }}'
           - name: '{{ tryton_user }}'
             role_attr_flags: SUPERUSER


### PR DESCRIPTION
Without OTRS can't access the view. This however is adds maintenance
costs as we'll need to update the permissions and provision every time
there's a new view to query.

It is safer and more maintainable to move these views within an otrs
schema where only the otrs has read access.