### PR TITLE
Allow TCP connections

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -41,6 +41,8 @@ db_options:
     value: on
   - option: log_disconnections
     value: on
+  - option: listen_addresses
+    value: '*'
 
 # Tryton Configuration files
 configuration_files:


### PR DESCRIPTION
This was the root cause of the "Connection refused" error we were
getting while testing the OTRS' contract view.