### PR TITLE
Update the Celery package to 4.3.0

### DIFF
--- a/roles/virtualenv/files/requirements.txt
+++ b/roles/virtualenv/files/requirements.txt
@@ -24,7 +24,7 @@ CairoSVG==1.0.22
 caldav==0.5.0
 # CDecimal 2.3 was deprecated https://pypi.org/project/cdecimal/2.3/
 http://www.bytereef.org/software/mpdecimal/releases/cdecimal-2.3.tar.gz
-celery==4.2.1
+celery==4.3.0
 celery-tryton==0.3
 certifi==2018.4.16
 cffi==1.9.1


### PR DESCRIPTION
We want to use the remote breakpoint to debug the Celery tasks and the
remote breakpoint was added in Celery release 4.3.0:

https://github.com/celery/celery/commit/f1a7b6eb82f9fb0222f22adfed277d0d7169dc91