### PR TITLE
Fix the default vars template. Checking if a variable is defined

### DIFF
--- a/roles/systemd_service/templates/defaults_trytond.j2
+++ b/roles/systemd_service/templates/defaults_trytond.j2
@@ -5,7 +5,7 @@ OTRS_RPC_PASSW="{{ otrs_rpc_passw }}"
 OTRS_URL="{{ otrs_url }}"
 OTRS_USER="{{ otrs_user }}"
 OTRS_PASSW="{{ otrs_password }}"
-{% if otrs_add_coverage_info_enabled | default(false) %}
+{% if otrs_add_coverage_info_enabled is defined %}
 OTRS_ADD_COVERAGE_INFO_ENABLED="{{ otrs_add_coverage_info_enabled }}"
 {% endif %}
 


### PR DESCRIPTION
Sorry, but the condition was wrong. To check if a variable is defined we need to use `is defined` in the condition.